### PR TITLE
fix: API 직렬화 에러 수정 및 테스트 추가

### DIFF
--- a/implementation/api/app/main.py
+++ b/implementation/api/app/main.py
@@ -9,6 +9,8 @@ from app.core.logging import setup_logging
 from app.middlewares.logging import LoggingMiddleware
 from app.routers import (
     rfid_router, 
+    auth_router,
+    users_router,
     pallets_router, 
     trace_router,
     items_router,
@@ -16,8 +18,6 @@ from app.routers import (
     reader_locations_router,
     lots_router,
     lot_genealogy_router,
-    # rfid_tags_router 삭제됨 - pallets로 통합
-    # rfid_tags_router 삭제됨 - pallets로 통합
     dashboard_router
 )
 from app.core.config import settings
@@ -58,6 +58,8 @@ app.add_middleware(LoggingMiddleware)
 app.mount("/socket.io", sio_app)
 
 # 라우터 등록
+app.include_router(auth_router, prefix="/api/v1/auth", tags=["Auth"])
+app.include_router(users_router, prefix="/api/v1/users", tags=["Users"])
 app.include_router(rfid_router, prefix="/api/v1/rfid", tags=["RFID"])
 app.include_router(pallets_router, prefix="/api/v1/pallets", tags=["Pallets"])
 app.include_router(trace_router, prefix="/api/v1/trace", tags=["Traceability"])
@@ -66,7 +68,6 @@ app.include_router(processes_router, prefix="/api/v1/processes", tags=["Processe
 app.include_router(reader_locations_router, prefix="/api/v1/reader-locations", tags=["Reader Locations"])
 app.include_router(lots_router, prefix="/api/v1/lots", tags=["Lots"])
 app.include_router(lot_genealogy_router, prefix="/api/v1/lot-genealogy", tags=["Lot Genealogy"])
-# rfid_tags_router 삭제됨 - pallets로 통합 (pallets.tag_status 사용)
 app.include_router(dashboard_router, prefix="/api/v1/dashboard", tags=["Dashboard"])
 
 @app.get("/")

--- a/implementation/api/app/routers/dashboard.py
+++ b/implementation/api/app/routers/dashboard.py
@@ -238,3 +238,38 @@ async def get_stock_inventory(
         stock_items.append(StockItem(**data))
     
     return StockInventoryResponse(stock_items=stock_items)
+
+
+@router.get("/recent-activities")
+async def get_recent_activities(
+    limit: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(PermissionChecker("dashboard", "read"))
+):
+    """
+    최근 활동 이력 (권한: dashboard:read)
+    
+    최근 팔레트 상태 변경 이력을 반환합니다.
+    """
+    histories = db.query(PalletHistory).order_by(
+        PalletHistory.scan_time.desc()
+    ).limit(limit).all()
+    
+    activities = []
+    for h in histories:
+        pallet = db.query(Pallet).filter(Pallet.id == h.pallet_id).first()
+        process = db.query(Process).filter(Process.id == h.process_id).first() if h.process_id else None
+        
+        activities.append({
+            "id": h.id,
+            "pallet_no": pallet.pallet_no if pallet else None,
+            "event_type": h.event_type,
+            "previous_status": h.previous_status,
+            "new_status": h.new_status,
+            "process_name": process.process_name if process else None,
+            "scan_time": h.scan_time,
+            "worker_name": h.worker_name,
+            "notes": h.notes
+        })
+    
+    return {"activities": activities, "total": len(activities)}

--- a/implementation/api/app/routers/processes.py
+++ b/implementation/api/app/routers/processes.py
@@ -9,7 +9,8 @@ from app.schemas.process import (
     ProcessCreate,
     ProcessUpdate,
     ProcessResponse,
-    ProcessOrderUpdate
+    ProcessOrderUpdate,
+    ProcessListResponse
 )
 
 from app.core.permissions import PermissionChecker
@@ -18,7 +19,7 @@ from app.models.user import User
 router = APIRouter()
 
 
-@router.get("")
+@router.get("", response_model=ProcessListResponse)
 async def list_processes(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
@@ -32,13 +33,13 @@ async def list_processes(
     processes = query.offset((page - 1) * per_page).limit(per_page).all()
     pages = (total + per_page - 1) // per_page if total > 0 else 1
     
-    return {
-        "items": processes,
-        "total": total,
-        "page": page,
-        "per_page": per_page,
-        "pages": pages
-    }
+    return ProcessListResponse(
+        items=[ProcessResponse.model_validate(p) for p in processes],
+        total=total,
+        page=page,
+        per_page=per_page,
+        pages=pages
+    )
 
 
 @router.get("/{id}", response_model=ProcessResponse)

--- a/implementation/api/app/routers/reader_locations.py
+++ b/implementation/api/app/routers/reader_locations.py
@@ -8,7 +8,8 @@ from app.models.rfid import RFIDReaderLocation
 from app.schemas.reader_location import (
     ReaderLocationCreate,
     ReaderLocationUpdate,
-    ReaderLocationResponse
+    ReaderLocationResponse,
+    ReaderLocationListResponse
 )
 
 from app.core.permissions import PermissionChecker
@@ -17,7 +18,7 @@ from app.models.user import User
 router = APIRouter()
 
 
-@router.get("")
+@router.get("", response_model=ReaderLocationListResponse)
 async def list_reader_locations(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
@@ -43,13 +44,31 @@ async def list_reader_locations(
     locations = query.offset((page - 1) * per_page).limit(per_page).all()
     pages = (total + per_page - 1) // per_page if total > 0 else 1
     
-    return {
-        "items": locations,
-        "total": total,
-        "page": page,
-        "per_page": per_page,
-        "pages": pages
-    }
+    # Response 변환
+    items = []
+    for loc in locations:
+        loc_dict = {
+            "id": loc.id,
+            "port_name": loc.port_name,
+            "process_id": loc.process_id,
+            "location_type": loc.location_type,
+            "description": loc.description,
+            "is_active": loc.is_active,
+            "created_at": getattr(loc, "created_at", None),
+            # "updated_at": getattr(loc, "updated_at", None), # TimestampSchema에 있다면
+            
+            "process_name": loc.process.process_name if loc.process else None,
+            "process_code": loc.process.process_code if loc.process else None
+        }
+        items.append(ReaderLocationResponse(**loc_dict))
+
+    return ReaderLocationListResponse(
+        items=items,
+        total=total,
+        page=page,
+        per_page=per_page,
+        pages=pages
+    )
 
 
 @router.get("/{id}", response_model=ReaderLocationResponse)

--- a/implementation/api/app/schemas/dashboard.py
+++ b/implementation/api/app/schemas/dashboard.py
@@ -34,7 +34,7 @@ class ReaderStatus(BaseSchema):
     id: int
     port_name: str
     process_name: Optional[str] = None
-    location_type: str
+    location_type: Optional[str] = None
     status: str = Field(..., description="CONNECTED, DISCONNECTED, ERROR")
     last_scan_time: Optional[datetime] = None
     is_active: bool = True

--- a/implementation/api/app/schemas/process.py
+++ b/implementation/api/app/schemas/process.py
@@ -31,3 +31,11 @@ class ProcessResponse(ProcessBase, TimestampSchema):
     id: int
     allowed_item_types: Optional[str] = None
     is_first_process: Optional[bool] = None
+
+
+class ProcessListResponse(BaseModel):
+    items: list[ProcessResponse]
+    total: int
+    page: int
+    per_page: int
+    pages: int

--- a/implementation/api/app/schemas/reader_location.py
+++ b/implementation/api/app/schemas/reader_location.py
@@ -27,5 +27,16 @@ class ReaderLocationResponse(ReaderLocationBase, TimestampSchema):
     id: int
     
     # 공정 정보 포함
+    display_name: Optional[str] = None
+    
+    # 공정 정보 포함
     process_name: Optional[str] = None
     process_code: Optional[str] = None
+
+
+class ReaderLocationListResponse(BaseModel):
+    items: list[ReaderLocationResponse]
+    total: int
+    page: int
+    per_page: int
+    pages: int

--- a/implementation/api/tests/test_dashboard_api.py
+++ b/implementation/api/tests/test_dashboard_api.py
@@ -38,3 +38,13 @@ def test_inventory_stock(client: TestClient):
     assert response.status_code == 200
     data = response.json()
     assert "stock_items" in data
+
+
+def test_recent_activities(client: TestClient):
+    """최근 활동 이력 조회 테스트"""
+    response = client.get("/api/v1/dashboard/recent-activities")
+    assert response.status_code == 200
+    data = response.json()
+    assert "activities" in data
+    assert "total" in data
+    assert isinstance(data["activities"], list)

--- a/implementation/api/tests/test_master_data.py
+++ b/implementation/api/tests/test_master_data.py
@@ -1,20 +1,58 @@
 from fastapi.testclient import TestClient
 
+
+# ============================================
+# Process Tests
+# ============================================
+
 def test_create_process(client: TestClient):
     response = client.post(
         "/api/v1/processes/",
         json={
             "process_code": "PROC-001",
             "process_name": "Test Process",
-            "process_type": "Manufacturing",
             "process_order": 1,
-            "description": "Test"
         }
     )
     assert response.status_code == 200 or response.status_code == 201
     data = response.json()
     assert data["process_code"] == "PROC-001"
     assert "id" in data
+
+
+def test_list_processes(client: TestClient):
+    """목록 조회 테스트 - 직렬화 에러 검출"""
+    # 먼저 데이터 생성
+    client.post("/api/v1/processes/", json={
+        "process_code": "LIST-PROC", "process_name": "List Test", "process_order": 99
+    })
+    
+    response = client.get("/api/v1/processes")
+    assert response.status_code == 200
+    data = response.json()
+    # 페이지네이션 응답 구조 확인
+    assert "items" in data
+    assert "total" in data
+    assert "page" in data
+    assert isinstance(data["items"], list)
+
+
+def test_get_process_detail(client: TestClient):
+    """상세 조회 테스트"""
+    create_res = client.post("/api/v1/processes/", json={
+        "process_code": "DETAIL-PROC", "process_name": "Detail Test", "process_order": 98
+    })
+    proc_id = create_res.json()["id"]
+    
+    response = client.get(f"/api/v1/processes/{proc_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["process_code"] == "DETAIL-PROC"
+
+
+# ============================================
+# Item Tests
+# ============================================
 
 def test_create_item(client: TestClient):
     response = client.post(
@@ -23,20 +61,35 @@ def test_create_item(client: TestClient):
             "item_code": "ITEM-001",
             "item_name": "Test Item",
             "item_type": "RAW",
-            "unit": "kg",
-            "description": "Test Material"
         }
     )
     assert response.status_code == 201
     data = response.json()
     assert data["item_code"] == "ITEM-001"
 
+
+def test_list_items(client: TestClient):
+    """목록 조회 테스트 - 직렬화 에러 검출"""
+    client.post("/api/v1/items/", json={
+        "item_code": "LIST-ITEM", "item_name": "List Test", "item_type": "RAW"
+    })
+    
+    response = client.get("/api/v1/items")
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert "total" in data
+
+
+# ============================================
+# Reader Location Tests
+# ============================================
+
 def test_create_reader_location(client: TestClient):
     # First create a process to link to
     proc_res = client.post("/api/v1/processes/", json={
         "process_code": "READER-PROC", 
         "process_name": "Reader Process",
-        "process_type": "Logistics",
         "process_order": 2
     })
     process_id = proc_res.json()["id"]
@@ -54,3 +107,13 @@ def test_create_reader_location(client: TestClient):
     data = response.json()
     assert data["port_name"] == "COM1"
     assert data["location_type"] == "IN"
+
+
+def test_list_reader_locations(client: TestClient):
+    """목록 조회 테스트 - 직렬화 에러 검출"""
+    response = client.get("/api/v1/reader-locations")
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert "total" in data
+    assert isinstance(data["items"], list)

--- a/implementation/database/init/01-schema.sql
+++ b/implementation/database/init/01-schema.sql
@@ -169,6 +169,29 @@ INSERT INTO processes (process_code, process_name, process_order, production_lin
 ('SHIPPING', '출하', 4, '출하장');
 
 -- ============================================
+-- 사용자 테이블 (추가)
+-- ============================================
+
+-- 8. 사용자 관리
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    username VARCHAR(50) UNIQUE NOT NULL COMMENT '사용자 아이디',
+    hashed_password VARCHAR(255) NOT NULL COMMENT '해싱된 비밀번호',
+    full_name VARCHAR(100) COMMENT '사용자 실명',
+    role VARCHAR(20) DEFAULT 'USER' COMMENT '권한 (ADMIN, USER)',
+    is_active BOOLEAN DEFAULT TRUE,
+    permissions JSON COMMENT '사용자 세부 권한 (JSON)',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_username (username)
+) COMMENT '사용자 관리';
+
+-- 기본 Admin 사용자 생성
+-- 비밀번호: admin123 (bcrypt 해싱됨)
+INSERT INTO users (username, hashed_password, full_name, role, is_active, permissions) VALUES
+('admin', '$2b$12$13zfEGam1CcnGzYS6cfGVe30h8eAbWrwv.JirjRp1tzem9Y.aVavi', 'Administrator', 'ADMIN', TRUE, '{}');
+
+-- ============================================
 -- 뷰 (Views)
 -- ============================================
 


### PR DESCRIPTION
## 수정한 문제

1. Auth/Users 라우터 미등록 (404)
   - main.py에 auth_router, users_router 등록 추가

2. Users 테이블 및 Admin 계정 누락 (401)
   - 01-schema.sql에 users 테이블 및 admin 시드 데이터 추가

3. Processes 직렬화 에러 (500)
   - ProcessListResponse 스키마 추가 및 변환 로직 적용

4. Reader-Locations 직렬화 에러 (500)
   - ReaderLocationListResponse 스키마 추가

5. Dashboard recent-activities 엔드포인트 누락 (404)
   - dashboard.py에 구현 추가

6. ReaderStatus.location_type 스키마 에러 (500)
   - Optional[str]로 변경
